### PR TITLE
refactor: replace hardcoded string labels with localizations in DNS and Analytics pages

### DIFF
--- a/lib/features/analytics/presentation/pages/analytics_page.dart
+++ b/lib/features/analytics/presentation/pages/analytics_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 class AnalyticsPage extends StatelessWidget {
   const AnalyticsPage({super.key, required this.navigationShell});
 
@@ -9,6 +11,8 @@ class AnalyticsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Scaffold(
       body: navigationShell,
       bottomNavigationBar: NavigationBar(
@@ -19,21 +23,21 @@ class AnalyticsPage extends StatelessWidget {
             initialLocation: index == navigationShell.currentIndex,
           );
         },
-        destinations: const [
+        destinations: [
           NavigationDestination(
-            icon: Icon(Symbols.public, fill: 0),
-            selectedIcon: Icon(Symbols.public, fill: 1),
-            label: 'Web',
+            icon: const Icon(Symbols.public, fill: 0),
+            selectedIcon: const Icon(Symbols.public, fill: 1),
+            label: l10n.tabs_web,
           ),
           NavigationDestination(
-            icon: Icon(Symbols.security, fill: 0),
-            selectedIcon: Icon(Symbols.security, fill: 1),
-            label: 'Security',
+            icon: const Icon(Symbols.security, fill: 0),
+            selectedIcon: const Icon(Symbols.security, fill: 1),
+            label: l10n.tabs_security,
           ),
           NavigationDestination(
-            icon: Icon(Symbols.cached, fill: 0),
-            selectedIcon: Icon(Symbols.cached, fill: 1),
-            label: 'Cache',
+            icon: const Icon(Symbols.cached, fill: 0),
+            selectedIcon: const Icon(Symbols.cached, fill: 1),
+            label: l10n.tabs_cache,
           ),
         ],
       ),

--- a/lib/features/dns/presentation/pages/dns_page.dart
+++ b/lib/features/dns/presentation/pages/dns_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../../../l10n/app_localizations.dart';
+
 /// DNS page container with bottom navigation
 class DnsPage extends StatelessWidget {
   const DnsPage({super.key, required this.navigationShell});
@@ -10,6 +12,8 @@ class DnsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Scaffold(
       body: navigationShell,
       bottomNavigationBar: NavigationBar(
@@ -20,21 +24,21 @@ class DnsPage extends StatelessWidget {
             initialLocation: index == navigationShell.currentIndex,
           );
         },
-        destinations: const [
+        destinations: [
           NavigationDestination(
-            icon: Icon(Symbols.graph_3, fill: 0),
-            selectedIcon: Icon(Symbols.graph_3, fill: 1),
-            label: 'Records',
+            icon: const Icon(Symbols.graph_3, fill: 0),
+            selectedIcon: const Icon(Symbols.graph_3, fill: 1),
+            label: l10n.tabs_records,
           ),
           NavigationDestination(
-            icon: Icon(Symbols.finance_mode, fill: 0),
-            selectedIcon: Icon(Symbols.finance_mode, fill: 1),
-            label: 'Analytics',
+            icon: const Icon(Symbols.finance_mode, fill: 0),
+            selectedIcon: const Icon(Symbols.finance_mode, fill: 1),
+            label: l10n.tabs_analytics,
           ),
           NavigationDestination(
-            icon: Icon(Symbols.settings, fill: 0),
-            selectedIcon: Icon(Symbols.settings, fill: 1),
-            label: 'Settings',
+            icon: const Icon(Symbols.settings, fill: 0),
+            selectedIcon: const Icon(Symbols.settings, fill: 1),
+            label: l10n.tabs_settings,
           ),
         ],
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -609,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -1118,10 +1118,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
I found two places where bottom navigation labels were hardcoded instead of using the app's `AppLocalizations`: in `AnalyticsPage` and `DnsPage`. This branch updates those labels to utilize the correctly localized string getters (e.g. `l10n.tabs_web` instead of `'Web'`). This improves the app's i18n support without adding any new translation keys since they were already defined in the `.arb` files. Tested using `make test` which passed successfully.

---
*PR created automatically by Jules for task [2493924915297917226](https://jules.google.com/task/2493924915297917226) started by @insign*