### PR TITLE
feat(dns): enable pull-to-refresh on empty records state

### DIFF
--- a/lib/features/dns/presentation/pages/dns_records_page.dart
+++ b/lib/features/dns/presentation/pages/dns_records_page.dart
@@ -78,43 +78,54 @@ class _DnsRecordsPageState extends ConsumerState<DnsRecordsPage> {
 
           // Record list
           Expanded(
-            child: AnimatedSwitcher(
-              duration: const Duration(milliseconds: 300),
-              child: filteredRecords.isEmpty
-                ? _buildEmptyState(state, l10n)
-                : RefreshIndicator(
-                    key: const ValueKey('list'),
-                    onRefresh: () =>
-                        ref.read(dnsRecordsNotifierProvider.notifier).refresh(),
-                    child: ListView.builder(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
+            child: RefreshIndicator(
+              onRefresh: () =>
+                  ref.read(dnsRecordsNotifierProvider.notifier).refresh(),
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                child: filteredRecords.isEmpty
+                    ? LayoutBuilder(
+                        key: const ValueKey('empty'),
+                        builder: (context, constraints) => SingleChildScrollView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          child: Container(
+                            constraints: BoxConstraints(
+                              minHeight: constraints.maxHeight,
+                            ),
+                            child: _buildEmptyState(state, l10n),
+                          ),
+                        ),
+                      )
+                    : ListView.builder(
+                        key: const ValueKey('list'),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        itemCount: filteredRecords.length,
+                        itemBuilder: (context, index) {
+                          final record = filteredRecords[index];
+                          return DnsRecordItem(
+                            record: record,
+                            isSaving: state.savingIds.contains(record.id),
+                            isNew: state.newIds.contains(record.id),
+                            isDeleting: state.deletingIds.contains(record.id),
+                            onTap: () => _showEditDialog(record),
+                            onDelete: () => _deleteRecord(record.id),
+                            onProxyToggle: (value) =>
+                                _toggleProxy(record.id, value),
+                          )
+                              .animate()
+                              .fadeIn(duration: 300.ms)
+                              .slideY(
+                                begin: 0.1,
+                                duration: 300.ms,
+                                curve: Curves.easeOutCubic,
+                                delay: (50 * index.clamp(0, 10)).ms,
+                              );
+                        },
                       ),
-                      itemCount: filteredRecords.length,
-                      itemBuilder: (context, index) {
-                        final record = filteredRecords[index];
-                        return DnsRecordItem(
-                          record: record,
-                          isSaving: state.savingIds.contains(record.id),
-                          isNew: state.newIds.contains(record.id),
-                          isDeleting: state.deletingIds.contains(record.id),
-                          onTap: () => _showEditDialog(record),
-                          onDelete: () => _deleteRecord(record.id),
-                          onProxyToggle: (value) =>
-                              _toggleProxy(record.id, value),
-                        )
-                            .animate()
-                            .fadeIn(duration: 300.ms)
-                            .slideY(
-                              begin: 0.1,
-                              duration: 300.ms,
-                              curve: Curves.easeOutCubic,
-                              delay: (50 * index.clamp(0, 10)).ms,
-                            );
-                      },
-                    ),
-                  ),
+              ),
             ),
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -609,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -1118,10 +1118,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Users were unable to refresh the DNS records list by swiping down if the list was empty or if their filter returned no results. This adds standard scrollability for pull-to-refresh on the empty state.

---
*PR created automatically by Jules for task [7181344422236344962](https://jules.google.com/task/7181344422236344962) started by @insign*