### PR TITLE
UX: Make empty states pull-to-refreshable

### DIFF
--- a/lib/features/dns/presentation/pages/dns_records_page.dart
+++ b/lib/features/dns/presentation/pages/dns_records_page.dart
@@ -80,41 +80,52 @@ class _DnsRecordsPageState extends ConsumerState<DnsRecordsPage> {
           Expanded(
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 300),
-              child: filteredRecords.isEmpty
-                ? _buildEmptyState(state, l10n)
-                : RefreshIndicator(
-                    key: const ValueKey('list'),
-                    onRefresh: () =>
-                        ref.read(dnsRecordsNotifierProvider.notifier).refresh(),
-                    child: ListView.builder(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
+              child: RefreshIndicator(
+                key: const ValueKey('list-indicator'),
+                onRefresh: () =>
+                    ref.read(dnsRecordsNotifierProvider.notifier).refresh(),
+                child: filteredRecords.isEmpty
+                    ? LayoutBuilder(
+                        builder: (context, constraints) => SingleChildScrollView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(
+                              minHeight: constraints.maxHeight,
+                            ),
+                            child: _buildEmptyState(state, l10n),
+                          ),
+                        ),
+                      )
+                    : ListView.builder(
+                        key: const ValueKey('list'),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        itemCount: filteredRecords.length,
+                        itemBuilder: (context, index) {
+                          final record = filteredRecords[index];
+                          return DnsRecordItem(
+                            record: record,
+                            isSaving: state.savingIds.contains(record.id),
+                            isNew: state.newIds.contains(record.id),
+                            isDeleting: state.deletingIds.contains(record.id),
+                            onTap: () => _showEditDialog(record),
+                            onDelete: () => _deleteRecord(record.id),
+                            onProxyToggle: (value) =>
+                                _toggleProxy(record.id, value),
+                          )
+                              .animate()
+                              .fadeIn(duration: 300.ms)
+                              .slideY(
+                                begin: 0.1,
+                                duration: 300.ms,
+                                curve: Curves.easeOutCubic,
+                                delay: (50 * index.clamp(0, 10)).ms,
+                              );
+                        },
                       ),
-                      itemCount: filteredRecords.length,
-                      itemBuilder: (context, index) {
-                        final record = filteredRecords[index];
-                        return DnsRecordItem(
-                          record: record,
-                          isSaving: state.savingIds.contains(record.id),
-                          isNew: state.newIds.contains(record.id),
-                          isDeleting: state.deletingIds.contains(record.id),
-                          onTap: () => _showEditDialog(record),
-                          onDelete: () => _deleteRecord(record.id),
-                          onProxyToggle: (value) =>
-                              _toggleProxy(record.id, value),
-                        )
-                            .animate()
-                            .fadeIn(duration: 300.ms)
-                            .slideY(
-                              begin: 0.1,
-                              duration: 300.ms,
-                              curve: Curves.easeOutCubic,
-                              delay: (50 * index.clamp(0, 10)).ms,
-                            );
-                      },
-                    ),
-                  ),
+              ),
             ),
           ),
         ],

--- a/lib/features/pages/presentation/pages/pages_list_page.dart
+++ b/lib/features/pages/presentation/pages/pages_list_page.dart
@@ -87,38 +87,44 @@ class _PagesListPageState extends ConsumerState<PagesListPage> {
     PagesProjectsState state,
     AppLocalizations l10n,
   ) {
-    if (state.projects.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Symbols.electric_bolt, size: 64, color: Colors.grey),
-            const SizedBox(height: 16),
-            Text(l10n.pages_noProjects),
-          ],
-        ),
-      );
-    }
-
     return RefreshIndicator(
       onRefresh: () =>
           ref.read(pagesProjectsNotifierProvider.notifier).refresh(),
-      child: ListView.builder(
-        padding: const EdgeInsets.all(16),
-        itemCount: state.projects.length,
-        itemBuilder: (context, index) {
-          final project = state.projects[index];
-          return _ProjectCard(project: project)
-              .animate()
-              .fadeIn(duration: 300.ms)
-              .slideY(
-                begin: 0.1,
-                duration: 300.ms,
-                curve: Curves.easeOutCubic,
-                delay: (50 * index.clamp(0, 10)).ms,
-              );
-        },
-      ),
+      child: state.projects.isEmpty
+          ? LayoutBuilder(
+              builder: (context, constraints) => SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Symbols.electric_bolt, size: 64, color: Colors.grey),
+                        const SizedBox(height: 16),
+                        Text(l10n.pages_noProjects),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: state.projects.length,
+              itemBuilder: (context, index) {
+                final project = state.projects[index];
+                return _ProjectCard(project: project)
+                    .animate()
+                    .fadeIn(duration: 300.ms)
+                    .slideY(
+                      begin: 0.1,
+                      duration: 300.ms,
+                      curve: Curves.easeOutCubic,
+                      delay: (50 * index.clamp(0, 10)).ms,
+                    );
+              },
+            ),
     );
   }
 }

--- a/lib/features/pages/presentation/pages/pages_project_page.dart
+++ b/lib/features/pages/presentation/pages/pages_project_page.dart
@@ -309,34 +309,40 @@ class _PagesProjectPageState extends ConsumerState<PagesProjectPage> {
     List<PagesDeployment> deployments,
     AppLocalizations l10n,
   ) {
-    if (deployments.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Symbols.cloud_off, size: 48, color: Colors.grey),
-            const SizedBox(height: 16),
-            Text(l10n.pages_noDeployments),
-          ],
-        ),
-      );
-    }
-
     return RefreshIndicator(
       onRefresh: () => ref
           .read(pagesDeploymentsNotifierProvider(projectName).notifier)
           .refresh(),
-      child: ListView.builder(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        itemCount: deployments.length,
-        itemBuilder: (context, index) {
-          final deployment = deployments[index];
-          return _DeploymentTile(
-            deployment: deployment,
-            projectName: projectName,
-          );
-        },
-      ),
+      child: deployments.isEmpty
+          ? LayoutBuilder(
+              builder: (context, constraints) => SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Symbols.cloud_off, size: 48, color: Colors.grey),
+                        const SizedBox(height: 16),
+                        Text(l10n.pages_noDeployments),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              itemCount: deployments.length,
+              itemBuilder: (context, index) {
+                final deployment = deployments[index];
+                return _DeploymentTile(
+                  deployment: deployment,
+                  projectName: projectName,
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/features/pages/presentation/widgets/pages_domains_tab.dart
+++ b/lib/features/pages/presentation/widgets/pages_domains_tab.dart
@@ -67,34 +67,40 @@ class PagesDomainsTab extends ConsumerWidget {
     List<PagesDomain> domains,
     AppLocalizations l10n,
   ) {
-    if (domains.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Symbols.language, size: 48, color: Colors.grey),
-            const SizedBox(height: 16),
-            Text(l10n.common_noData),
-          ],
-        ),
-      );
-    }
-
     return RefreshIndicator(
       onRefresh: () =>
           ref.read(pagesDomainsNotifierProvider(project.name).notifier).refresh(),
-      child: ListView.separated(
-        padding: const EdgeInsets.all(16),
-        itemCount: domains.length,
-        separatorBuilder: (context, index) => const SizedBox(height: 8),
-        itemBuilder: (context, index) {
-          final domain = domains[index];
-          return _DomainTile(
-            domain: domain,
-            projectName: project.name,
-          );
-        },
-      ),
+      child: domains.isEmpty
+          ? LayoutBuilder(
+              builder: (context, constraints) => SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Symbols.language, size: 48, color: Colors.grey),
+                        const SizedBox(height: 16),
+                        Text(l10n.common_noData),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: domains.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final domain = domains[index];
+                return _DomainTile(
+                  domain: domain,
+                  projectName: project.name,
+                );
+              },
+            ),
     );
   }
 

--- a/lib/features/workers/presentation/pages/workers_list_page.dart
+++ b/lib/features/workers/presentation/pages/workers_list_page.dart
@@ -53,13 +53,6 @@ class WorkersListPage extends ConsumerWidget {
                   onRetry: () => ref.read(workersNotifierProvider.notifier).refresh(),
                 ),
                 data: (state) {
-                  if (state.workers.isEmpty && !state.isRefreshing) {
-                    return KeyedSubtree(
-                      key: const ValueKey('empty'),
-                      child: _buildEmptyState(context, l10n),
-                    );
-                  }
-
                   return Column(
                     key: const ValueKey('data'),
                     children: [
@@ -68,24 +61,42 @@ class WorkersListPage extends ConsumerWidget {
                       Expanded(
                         child: RefreshIndicator(
                           onRefresh: () => ref.read(workersNotifierProvider.notifier).refresh(),
-                          child: filteredWorkersList.isEmpty && !state.isRefreshing
-                              ? Center(child: Text(l10n.emptyState_tryAdjustingSearch))
-                              : ListView.builder(
-                                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                                  itemCount: filteredWorkersList.length,
-                                  itemBuilder: (context, index) {
-                                    final worker = filteredWorkersList[index];
-                                    return _WorkerCard(worker: worker)
-                                        .animate()
-                                        .fadeIn(duration: 300.ms)
-                                        .slideY(
-                                          begin: 0.1,
-                                          duration: 300.ms,
-                                          curve: Curves.easeOutCubic,
-                                          delay: (50 * index.clamp(0, 10)).ms,
-                                        );
-                                  },
-                                ),
+                          child: (state.workers.isEmpty && !state.isRefreshing)
+                              ? LayoutBuilder(
+                                  builder: (context, constraints) => SingleChildScrollView(
+                                    physics: const AlwaysScrollableScrollPhysics(),
+                                    child: ConstrainedBox(
+                                      constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                                      child: _buildEmptyState(context, l10n),
+                                    ),
+                                  ),
+                                )
+                              : (filteredWorkersList.isEmpty && !state.isRefreshing)
+                                  ? LayoutBuilder(
+                                      builder: (context, constraints) => SingleChildScrollView(
+                                        physics: const AlwaysScrollableScrollPhysics(),
+                                        child: ConstrainedBox(
+                                          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                                          child: Center(child: Text(l10n.emptyState_tryAdjustingSearch)),
+                                        ),
+                                      ),
+                                    )
+                                  : ListView.builder(
+                                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                                      itemCount: filteredWorkersList.length,
+                                      itemBuilder: (context, index) {
+                                        final worker = filteredWorkersList[index];
+                                        return _WorkerCard(worker: worker)
+                                            .animate()
+                                            .fadeIn(duration: 300.ms)
+                                            .slideY(
+                                              begin: 0.1,
+                                              duration: 300.ms,
+                                              curve: Curves.easeOutCubic,
+                                              delay: (50 * index.clamp(0, 10)).ms,
+                                            );
+                                      },
+                                    ),
                         ),
                       ),
                     ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -609,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -1118,10 +1118,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
UX: Make empty states pull-to-refreshable

This resolves a widespread UX issue where users were unable to refresh lists that were empty, since `RefreshIndicator` requires a scrollable child. Now, empty states in `DnsRecordsPage`, `WorkersListPage`, `PagesListPage`, `PagesProjectPage`, and `PagesDomainsTab` use a `LayoutBuilder` with a `SingleChildScrollView(physics: AlwaysScrollableScrollPhysics())` to natively support pull-to-refresh even when there is no data.

---
*PR created automatically by Jules for task [18018732928588099248](https://jules.google.com/task/18018732928588099248) started by @insign*