### PR TITLE
Fix: Resolver warnings de build_context_synchronously no WorkerSettingsTab

### DIFF
--- a/lib/features/workers/presentation/widgets/worker_settings_tab.dart
+++ b/lib/features/workers/presentation/widgets/worker_settings_tab.dart
@@ -278,12 +278,15 @@ class _WorkerSettingsTabState extends ConsumerState<WorkerSettingsTab> {
       'https://dash.cloudflare.com/$accountId/workers/services/view/${widget.worker.id}/builds',
     );
 
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = AppLocalizations.of(context);
+
     if (await canLaunchUrl(url)) {
       await launchUrl(url, mode: LaunchMode.externalApplication);
     } else {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).common_error)),
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.common_error)),
       );
     }
   }
@@ -660,6 +663,7 @@ class _WorkerSettingsTabState extends ConsumerState<WorkerSettingsTab> {
           FilledButton(
             onPressed: () async {
               if (controller.text.isEmpty) return;
+              final messenger = ScaffoldMessenger.of(context);
               Navigator.pop(context);
               final success = await ref.read(workerSettingsActionNotifierProvider.notifier).updateSecret(
                 scriptName: widget.worker.id,
@@ -667,7 +671,7 @@ class _WorkerSettingsTabState extends ConsumerState<WorkerSettingsTab> {
                 text: controller.text.trim(),
               );
               if (success && mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
+                messenger.showSnackBar(
                   SnackBar(content: Text(l10n.pages_settingsUpdated)),
                 );
               }


### PR DESCRIPTION
Esta melhoria tem valor real porque elimina os warnings de `use_build_context_synchronously` detectados pelo `flutter analyze` em `worker_settings_tab.dart`. Isso previne bugs em tempo de execução (como tentar usar o `BuildContext` depois do widget já ter sido desmontado de memória, ex: em um fechamento assíncrono de janela) e ao mesmo tempo mantém o limite de issues estáticas no budget da CI menor que antes, garantindo maior integridade nas execuções de `make analyze` e `make precommit`.

### O que foi feito:
- Foram armazenados as referências para `ScaffoldMessenger.of(context)` e `AppLocalizations.of(context)` em variáveis locais antes de comandos `await` nos métodos `_openGitBuildDashboard` e `_showUpdateSecretDialog`. 
- Nenhum arquivo além do estritamente necessário para essa melhora (apenas `worker_settings_tab.dart`) foi alterado e o arquivo `.lock` não sofreu nenhum tipo de alteração em suas dependências, cumprindo com as regras rígidas passadas pelo usuário.
- Nenhum update em `ROADMAP.md`, `.md` etc. foi feito porque a mudança é específica de correção de warnings não afetando as features. Testes rodados sem regressões.

---
*PR created automatically by Jules for task [3219110886501850513](https://jules.google.com/task/3219110886501850513) started by @insign*