### PR TITLE
Fix missing SharedPreferences mock in provider tests

### DIFF
--- a/test/unit/providers/pages_provider_test.dart
+++ b/test/unit/providers/pages_provider_test.dart
@@ -84,6 +84,7 @@ void main() {
         projectsJson,
         (json) => (json as List).map((e) => PagesProject.fromJson(e)).toList(),
       );
+      when(() => mockPrefs.setString(any(), any())).thenAnswer((_) async => true);
       when(() => mockApi.getPagesProjects(accountId, page: any(named: 'page')))
           .thenAnswer((_) async => mockResponse);
 

--- a/test/unit/providers/workers_provider_test.dart
+++ b/test/unit/providers/workers_provider_test.dart
@@ -83,6 +83,7 @@ void main() {
         scriptsJson,
         (json) => (json as List).map((e) => Worker.fromJson(e)).toList(),
       );
+      when(() => mockPrefs.setString(any(), any())).thenAnswer((_) async => true);
       when(() => mockApi.getWorkersScripts(accountId))
           .thenAnswer((_) async => mockResponse);
 


### PR DESCRIPTION
This PR fixes `TypeError: type 'Null' is not a subtype of type 'Future<bool>'` in unit tests, which occurred because `SharedPreferences.setString` wasn't mocked properly in background-refresh tests for `pages_provider_test.dart` and `workers_provider_test.dart`.

By explicitly mocking `setString` to return `true`, we ensure tests don't throw unchecked exceptions and log false "Failed to save cache" warnings, making the test suite cleaner and more reliable.

---
*PR created automatically by Jules for task [16750247941995213940](https://jules.google.com/task/16750247941995213940) started by @insign*