### PR TITLE
Fix RangeError when baseDelayMs is 0 in RetryInterceptor

### DIFF
--- a/lib/core/api/interceptors/retry_interceptor.dart
+++ b/lib/core/api/interceptors/retry_interceptor.dart
@@ -32,7 +32,8 @@ class RetryInterceptor extends Interceptor {
 
       log.warning(
         'Retrying ${err.requestOptions.method} ${err.requestOptions.path}',
-        details: 'Attempt ${retryCount + 1}/$maxRetries after ${delay}ms (status: $statusCode, type: ${err.type.name})',
+        details:
+            'Attempt ${retryCount + 1}/$maxRetries after ${delay}ms (status: $statusCode, type: ${err.type.name})',
       );
 
       await Future.delayed(Duration(milliseconds: delay));
@@ -60,7 +61,9 @@ class RetryInterceptor extends Interceptor {
           'Retry failed for ${err.requestOptions.method} ${err.requestOptions.path}',
           error: e,
         );
-        handler.next(DioException(requestOptions: err.requestOptions, error: e));
+        handler.next(
+          DioException(requestOptions: err.requestOptions, error: e),
+        );
         return;
       }
     }
@@ -107,7 +110,7 @@ class RetryInterceptor extends Interceptor {
 
     // Exponential backoff with jitter
     final exponentialDelay = baseDelayMs * pow(2, retryCount).toInt();
-    final jitter = Random().nextInt(baseDelayMs);
+    final jitter = baseDelayMs > 0 ? Random().nextInt(baseDelayMs) : 0;
     return exponentialDelay + jitter;
   }
 }

--- a/test/unit/api/retry_interceptor_test.dart
+++ b/test/unit/api/retry_interceptor_test.dart
@@ -11,9 +11,15 @@ class MockErrorInterceptorHandler extends Mock
 void main() {
   setUpAll(() {
     registerFallbackValue(RequestOptions(path: ''));
-    registerFallbackValue(Response<dynamic>(
-        requestOptions: RequestOptions(path: ''), statusCode: 200));
-    registerFallbackValue(DioException(requestOptions: RequestOptions(path: '')));
+    registerFallbackValue(
+      Response<dynamic>(
+        requestOptions: RequestOptions(path: ''),
+        statusCode: 200,
+      ),
+    );
+    registerFallbackValue(
+      DioException(requestOptions: RequestOptions(path: '')),
+    );
   });
 
   group('RetryInterceptor', () {
@@ -269,8 +275,11 @@ void main() {
     });
 
     test('stops retrying after maxRetries exhausted', () async {
-      final interceptor2 =
-          RetryInterceptor(dio: mockDio, baseDelayMs: 1, maxRetries: 2);
+      final interceptor2 = RetryInterceptor(
+        dio: mockDio,
+        baseDelayMs: 1,
+        maxRetries: 2,
+      );
       // Simulate already at max retries
       final opts = RequestOptions(path: '/test');
       opts.extra['retryCount'] = 2;
@@ -287,30 +296,32 @@ void main() {
       verify(() => handler.next(any())).called(1);
     });
 
-    test('propagates DioException when retry fails with DioException',
-        () async {
-      final error = DioException(
-        requestOptions: RequestOptions(path: '/test'),
-        response: Response(
+    test(
+      'propagates DioException when retry fails with DioException',
+      () async {
+        final error = DioException(
           requestOptions: RequestOptions(path: '/test'),
-          statusCode: 500,
-        ),
-      );
-      final handler = MockErrorInterceptorHandler();
+          response: Response(
+            requestOptions: RequestOptions(path: '/test'),
+            statusCode: 500,
+          ),
+        );
+        final handler = MockErrorInterceptorHandler();
 
-      when(() => mockDio.fetch<dynamic>(any())).thenThrow(
-        DioException(
-          requestOptions: RequestOptions(path: '/test'),
-          type: DioExceptionType.connectionError,
-        ),
-      );
+        when(() => mockDio.fetch<dynamic>(any())).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/test'),
+            type: DioExceptionType.connectionError,
+          ),
+        );
 
-      await interceptor.onError(error, handler);
+        await interceptor.onError(error, handler);
 
-      verify(() => mockDio.fetch<dynamic>(any())).called(1);
-      verify(() => handler.next(any())).called(1);
-      verifyNever(() => handler.resolve(any()));
-    });
+        verify(() => mockDio.fetch<dynamic>(any())).called(1);
+        verify(() => handler.next(any())).called(1);
+        verifyNever(() => handler.resolve(any()));
+      },
+    );
 
     test('wraps non-DioException in DioException when retry fails', () async {
       final error = DioException(
@@ -322,14 +333,36 @@ void main() {
       );
       final handler = MockErrorInterceptorHandler();
 
-      when(() => mockDio.fetch<dynamic>(any()))
-          .thenThrow(Exception('unexpected'));
+      when(
+        () => mockDio.fetch<dynamic>(any()),
+      ).thenThrow(Exception('unexpected'));
 
       await interceptor.onError(error, handler);
 
       verify(() => mockDio.fetch<dynamic>(any())).called(1);
       verify(() => handler.next(any())).called(1);
       verifyNever(() => handler.resolve(any()));
+    });
+
+    test('does not crash when baseDelayMs is 0', () async {
+      final interceptorZero = RetryInterceptor(dio: mockDio, baseDelayMs: 0);
+      final error = DioException(
+        requestOptions: RequestOptions(path: '/test'),
+        type: DioExceptionType.connectionTimeout,
+      );
+      final handler = MockErrorInterceptorHandler();
+
+      when(() => mockDio.fetch<dynamic>(any())).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/test'),
+          statusCode: 200,
+        ),
+      );
+
+      await interceptorZero.onError(error, handler);
+
+      verify(() => mockDio.fetch<dynamic>(any())).called(1);
+      verify(() => handler.resolve(any())).called(1);
     });
 
     test('increments retryCount in request options', () async {
@@ -341,12 +374,8 @@ void main() {
       final handler = MockErrorInterceptorHandler();
 
       when(() => mockDio.fetch<dynamic>(any())).thenAnswer((invocation) async {
-        capturedOptions =
-            invocation.positionalArguments[0] as RequestOptions;
-        return Response(
-          requestOptions: capturedOptions!,
-          statusCode: 200,
-        );
+        capturedOptions = invocation.positionalArguments[0] as RequestOptions;
+        return Response(requestOptions: capturedOptions!, statusCode: 200);
       });
 
       await interceptor.onError(error, handler);


### PR DESCRIPTION
Fixes a potential crash in `RetryInterceptor` where initializing it with `baseDelayMs: 0` would result in a `RangeError` during jitter calculation because `Random().nextInt()` requires the max value to be positive and greater than 0.

This improvement makes the code more robust against configuration values and adds proper testing to ensure delays can be entirely disabled safely. No external files or markdown files needed updates.

---
*PR created automatically by Jules for task [5163655667391014827](https://jules.google.com/task/5163655667391014827) started by @insign*